### PR TITLE
pipeline fixes

### DIFF
--- a/.github/actions/migrate-db/migrate.sh
+++ b/.github/actions/migrate-db/migrate.sh
@@ -13,7 +13,7 @@ oc login $OPENSHIFT_SERVER --token=$TOKEN --insecure-skip-tls-verify=true
 oc project $NAMESPACE
 
 #set up port forwarding to access the database
-POD_NAME=$(oc get pod -l name=nestjs-app -o jsonpath="{.items[0].metadata.name}")
+POD_NAME=$(oc get pod -l name=sidecar -o jsonpath="{.items[0].metadata.name}")
 
 oc cp ./apps/api/prisma $POD_NAME:/tmp/prisma
 

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -19,6 +19,7 @@ jobs:
         id: get-changed-apps
         uses: dorny/paths-filter@v2
         with:
+          base: ${{ github.event.client_payload.ref }}
           ref: ${{ github.event.client_payload.ref }}
           filters: |
             api:

--- a/deployments/openshift/kustomize/sidecar/dc.yml
+++ b/deployments/openshift/kustomize/sidecar/dc.yml
@@ -1,0 +1,34 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: sidecar
+spec:
+  strategy:
+    type: Rolling
+  replicas: 1
+  selector:
+    name: sidecar
+  template:
+    metadata:
+      labels:
+        name: sidecar
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: sidecar
+        image: node:18.17.0
+        command: ["node"]
+        args: ["-e", "setInterval(() => console.log('Node.js is running'), 1000 * 60 * 60);"]  # Replace with your application command
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        env:
+        - name: npm_config_cache
+          value: "/tmp/.npm"
+        envFrom:
+        - secretRef:
+            name: secrets
+        resources:
+          requests:
+            cpu: 50m 
+            memory: 100Mi 

--- a/deployments/openshift/kustomize/sidecar/kustomization.yml
+++ b/deployments/openshift/kustomize/sidecar/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- dc.yml


### PR DESCRIPTION
Change migrate-db action to use sidecar deployment, so its not dependant on a running API pod, which can be finicky in dev/test.

fix build-apps bug where the paths-filter is always using main branch for comparison