### PR TITLE
Feature/al 553 org chart performance

### DIFF
--- a/apps/api/src/modules/external/org-chart.service.ts
+++ b/apps/api/src/modules/external/org-chart.service.ts
@@ -23,8 +23,11 @@ export class OrgChartService {
     const classifications = await this.classificationService.getClassifications({});
     const departments = await this.departmentService.getDepartments();
 
-    const positionIds = (result?.data?.query?.rows ?? []).map((row) => row['A.POSITION_NBR']);
-    const employees: Map<string, Employee[]> = await this.peoplesoftService.getEmployeesForPositions(positionIds);
+    const positionsWithIncumbentsIds = (result?.data?.query?.rows ?? [])
+      .filter((row) => row['A.UPDATE_INCUMBENTS'] === 'Y')
+      .map((row) => row['A.POSITION_NBR']);
+    const employees: Map<string, Employee[]> =
+      await this.peoplesoftService.getEmployeesForPositions(positionsWithIncumbentsIds);
 
     // Loop through response and generate the tree for everyone in the _current department_
     (result?.data?.query?.rows ?? []).forEach((position) => {

--- a/apps/api/src/modules/external/peoplesoft.service.ts
+++ b/apps/api/src/modules/external/peoplesoft.service.ts
@@ -378,89 +378,41 @@ export class PeoplesoftService {
   }
 
   async getPositionsForDepartment(department_id: string) {
-    const responses = await Promise.allSettled([
-      firstValueFrom(
-        this.request({
-          method: RequestMethod.GET,
-          endpoint: Endpoint.HrScope,
-          pageSize: 0,
-          extra: `prompt_uniquepromptname=DEPTID,POSITION_NBR&prompt_fieldvalue=${department_id},`,
-        }).pipe(
-          map((r) => r.data),
-          retry(3),
-          catchError((err) => {
-            throw new Error(err);
-          }),
-        ),
+    const response = await firstValueFrom(
+      this.request({
+        method: RequestMethod.GET,
+        endpoint: Endpoint.HrScope,
+        pageSize: 0,
+        extra: `prompt_uniquepromptname=DEPTID,POSITION_NBR,REPORTS_TO&prompt_fieldvalue=${department_id},,`,
+      }).pipe(
+        map((r) => r.data),
+        retry(3),
+        catchError((err) => {
+          throw new Error(err);
+        }),
       ),
-      firstValueFrom(
-        this.request({
-          method: RequestMethod.GET,
-          endpoint: Endpoint.HrScope,
-          pageSize: 0,
-          extra: `prompt_uniquepromptname=DEPTID,POSITION_NBR,REPORTS_TO&prompt_fieldvalue=${department_id},,`,
-        }).pipe(
-          map((r) => r.data),
-          retry(3),
-          catchError((err) => {
-            throw new Error(err);
-          }),
-        ),
-      ),
-    ]);
-
-    const successfulResponse = responses.find(
-      (response) => response.status === 'fulfilled' && response.value.status === 'success',
     );
 
-    return (
-      successfulResponse.status === 'fulfilled' &&
-      successfulResponse.value.status === 'success' &&
-      successfulResponse.value
-    );
+    return response;
   }
 
   async getPosition(position_id: string) {
-    const responses = await Promise.allSettled([
-      firstValueFrom(
-        this.request({
-          method: RequestMethod.GET,
-          endpoint: Endpoint.HrScope,
-          pageSize: 0,
-          extra: `prompt_uniquepromptname=DEPTID,POSITION_NBR&prompt_fieldvalue=,${position_id}`,
-        }).pipe(
-          map((r) => r.data),
-          retry(3),
-          catchError((err) => {
-            throw new Error(err);
-          }),
-        ),
+    const response = await firstValueFrom(
+      this.request({
+        method: RequestMethod.GET,
+        endpoint: Endpoint.HrScope,
+        pageSize: 0,
+        extra: `prompt_uniquepromptname=DEPTID,POSITION_NBR,REPORTS_TO&prompt_fieldvalue=,${position_id},`,
+      }).pipe(
+        map((r) => r.data),
+        retry(3),
+        catchError((err) => {
+          throw new Error(err);
+        }),
       ),
-      firstValueFrom(
-        this.request({
-          method: RequestMethod.GET,
-          endpoint: Endpoint.HrScope,
-          pageSize: 0,
-          extra: `prompt_uniquepromptname=DEPTID,POSITION_NBR,REPORTS_TO&prompt_fieldvalue=,${position_id},`,
-        }).pipe(
-          map((r) => r.data),
-          retry(3),
-          catchError((err) => {
-            throw new Error(err);
-          }),
-        ),
-      ),
-    ]);
-
-    const successfulResponse = responses.find(
-      (response) => response.status === 'fulfilled' && response.value.status === 'success',
     );
 
-    return (
-      successfulResponse.status === 'fulfilled' &&
-      successfulResponse.value.status === 'success' &&
-      successfulResponse.value
-    );
+    return response;
   }
 
   async createPosition(data: PositionCreateInput) {


### PR DESCRIPTION
Remove extra API call to historical endpoint.
Only fetch employees for positions _we know_ have employees.