### PR TITLE
hide optional accountability title on review page

### DIFF
--- a/.changeset/old-items-happen.md
+++ b/.changeset/old-items-happen.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+AL-612 Do not show optional accountability title on review page when none were selected

--- a/apps/app/src/routes/job-profiles/components/job-profile.component.tsx
+++ b/apps/app/src/routes/job-profiles/components/job-profile.component.tsx
@@ -557,7 +557,8 @@ export const JobProfile: React.FC<JobProfileProps> = ({
                     })}
             </ul>
             {/* Optional Accountabilities - is_significant == false */}
-            <h4>Optional accountabilities</h4>
+            {(effectiveData?.accountabilities.filter((acc) => !acc.is_significant && !acc.disabled)?.length ?? 0) >
+              0 && <h4>Optional accountabilities</h4>}
             <ul data-testid="optional-accountabilities">
               {showDiff && originalData
                 ? compareLists(
@@ -590,7 +591,9 @@ export const JobProfile: React.FC<JobProfileProps> = ({
       children: (
         <>
           <span tabIndex={0}>
-            <h4>Education</h4>
+            {(showDiff || (!showDiff && (effectiveData?.education.filter((ed) => !ed.disabled)?.length ?? 0) > 0)) && (
+              <h4>Education</h4>
+            )}
             <ul data-testid="education">
               {showDiff && originalData
                 ? compareLists(originalData.education, effectiveData?.education)


### PR DESCRIPTION
- AL-612 Do not show optional accountability title on review page when none were selected
- also hidden education title if that is empty