### PR TITLE
division and branch fields, other minor critical changes

### DIFF
--- a/.changeset/famous-dragons-invite.md
+++ b/.changeset/famous-dragons-invite.md
@@ -5,3 +5,7 @@
 AL-624 Amendment banner on the edit page needs to show consistent information
 AL-398 HM Testing - Edit form - review validation - e.x. drop or invalidate empty fields
 AL-623 Check if sections have adequate number of fields
+AL-620 HM: Add ‘Division’ and ‘Branch’ fields to the 'Additional details' page
+AL-621 The banner text on the actions page when the ticket is in ‘Ready’ state needs to be updated.
+AL-631 'Reset changes' button populates wrong data
+AL-622 Add a reminder for users to refrain from making any changes to the approved profile during recruitment.

--- a/apps/api/prisma/migrations/20240430160005_add_additional_info_json_migrate_data/migration.sql
+++ b/apps/api/prisma/migrations/20240430160005_add_additional_info_json_migrate_data/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "position_request" ADD COLUMN     "additional_info" JSONB;
+
+-- Migrate data from old columns to the new JSON column
+UPDATE "position_request"
+SET "additional_info" = jsonb_build_object(
+  'work_location_id', "additional_info_work_location_id",
+  'department_id', "additional_info_department_id",
+  'excluded_mgr_position_number', "additional_info_excluded_mgr_position_number", 
+  'comments', "additional_info_comments"
+);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -75,6 +75,8 @@ model PositionRequest {
   additional_info_excluded_mgr_position_number String?
   additional_info_comments                     String?
 
+  additional_info Json? @db.JsonB
+
   // TODO: AL-146
   // user        User       @relation(fields: [user_id], references: [id])
   // classification     Classification @relation(fields: [classification_id], references: [id])

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-count-aggregate.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-count-aggregate.input.ts
@@ -84,5 +84,8 @@ export class PositionRequestCountAggregateInput {
   additional_info_comments?: true;
 
   @Field(() => Boolean, { nullable: true })
+  additional_info?: true;
+
+  @Field(() => Boolean, { nullable: true })
   _all?: true;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-count-aggregate.output.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-count-aggregate.output.ts
@@ -84,5 +84,8 @@ export class PositionRequestCountAggregate {
   additional_info_comments!: number;
 
   @Field(() => Int, { nullable: false })
+  additional_info!: number;
+
+  @Field(() => Int, { nullable: false })
   _all!: number;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-count-order-by-aggregate.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-count-order-by-aggregate.input.ts
@@ -83,4 +83,7 @@ export class PositionRequestCountOrderByAggregateInput {
 
   @Field(() => SortOrder, { nullable: true })
   additional_info_comments?: keyof typeof SortOrder;
+
+  @Field(() => SortOrder, { nullable: true })
+  additional_info?: keyof typeof SortOrder;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many-department.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestCreateManyDepartmentInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many-parent-job-profile.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many-parent-job-profile.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestCreateManyParent_job_profileInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many-paylist-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many-paylist-department.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestCreateManyPaylist_departmentInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many-work-location.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many-work-location.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestCreateManyWorkLocationInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-many.input.ts
@@ -84,4 +84,7 @@ export class PositionRequestCreateManyInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-without-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-without-department.input.ts
@@ -73,6 +73,9 @@ export class PositionRequestCreateWithoutDepartmentInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => JobProfileCreateNestedOneWithoutPosition_requestInput, { nullable: true })
   parent_job_profile?: JobProfileCreateNestedOneWithoutPosition_requestInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-without-parent-job-profile.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-without-parent-job-profile.input.ts
@@ -73,6 +73,9 @@ export class PositionRequestCreateWithoutParent_job_profileInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => DepartmentCreateNestedOneWithoutPositionRequestInput, { nullable: false })
   department!: DepartmentCreateNestedOneWithoutPositionRequestInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-without-paylist-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-without-paylist-department.input.ts
@@ -73,6 +73,9 @@ export class PositionRequestCreateWithoutPaylist_departmentInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => JobProfileCreateNestedOneWithoutPosition_requestInput, { nullable: true })
   parent_job_profile?: JobProfileCreateNestedOneWithoutPosition_requestInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-without-work-location.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create-without-work-location.input.ts
@@ -73,6 +73,9 @@ export class PositionRequestCreateWithoutWorkLocationInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => JobProfileCreateNestedOneWithoutPosition_requestInput, { nullable: true })
   parent_job_profile?: JobProfileCreateNestedOneWithoutPosition_requestInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-create.input.ts
@@ -74,6 +74,9 @@ export class PositionRequestCreateInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => JobProfileCreateNestedOneWithoutPosition_requestInput, { nullable: true })
   parent_job_profile?: JobProfileCreateNestedOneWithoutPosition_requestInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-group-by.output.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-group-by.output.ts
@@ -90,6 +90,9 @@ export class PositionRequestGroupBy {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => PositionRequestCountAggregate, { nullable: true })
   _count?: PositionRequestCountAggregate;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-order-by-with-aggregation.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-order-by-with-aggregation.input.ts
@@ -90,6 +90,9 @@ export class PositionRequestOrderByWithAggregationInput {
   @Field(() => SortOrderInput, { nullable: true })
   additional_info_comments?: SortOrderInput;
 
+  @Field(() => SortOrderInput, { nullable: true })
+  additional_info?: SortOrderInput;
+
   @Field(() => PositionRequestCountOrderByAggregateInput, { nullable: true })
   _count?: PositionRequestCountOrderByAggregateInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-order-by-with-relation-and-search-relevance.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-order-by-with-relation-and-search-relevance.input.ts
@@ -89,6 +89,9 @@ export class PositionRequestOrderByWithRelationAndSearchRelevanceInput {
   @Field(() => SortOrderInput, { nullable: true })
   additional_info_comments?: SortOrderInput;
 
+  @Field(() => SortOrderInput, { nullable: true })
+  additional_info?: SortOrderInput;
+
   @Field(() => JobProfileOrderByWithRelationAndSearchRelevanceInput, { nullable: true })
   parent_job_profile?: JobProfileOrderByWithRelationAndSearchRelevanceInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-scalar-field.enum.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-scalar-field.enum.ts
@@ -28,6 +28,7 @@ export enum PositionRequestScalarFieldEnum {
   additional_info_department_id = 'additional_info_department_id',
   additional_info_excluded_mgr_position_number = 'additional_info_excluded_mgr_position_number',
   additional_info_comments = 'additional_info_comments',
+  additional_info = 'additional_info',
 }
 
 registerEnumType(PositionRequestScalarFieldEnum, { name: 'PositionRequestScalarFieldEnum', description: undefined });

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-scalar-where-with-aggregates.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-scalar-where-with-aggregates.input.ts
@@ -97,4 +97,7 @@ export class PositionRequestScalarWhereWithAggregatesInput {
 
   @Field(() => StringWithAggregatesFilter, { nullable: true })
   additional_info_comments?: StringWithAggregatesFilter;
+
+  @Field(() => JsonWithAggregatesFilter, { nullable: true })
+  additional_info?: JsonWithAggregatesFilter;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-scalar-where.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-scalar-where.input.ts
@@ -97,4 +97,7 @@ export class PositionRequestScalarWhereInput {
 
   @Field(() => StringFilter, { nullable: true })
   additional_info_comments?: StringFilter;
+
+  @Field(() => JsonFilter, { nullable: true })
+  additional_info?: JsonFilter;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create-without-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create-without-department.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedCreateWithoutDepartmentInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create-without-parent-job-profile.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create-without-parent-job-profile.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedCreateWithoutParent_job_profileInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create-without-paylist-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create-without-paylist-department.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedCreateWithoutPaylist_departmentInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create-without-work-location.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create-without-work-location.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedCreateWithoutWorkLocationInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-create.input.ts
@@ -84,4 +84,7 @@ export class PositionRequestUncheckedCreateInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many-without-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many-without-department.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedUpdateManyWithoutDepartmentInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many-without-parent-job-profile.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many-without-parent-job-profile.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedUpdateManyWithoutParent_job_profileInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many-without-paylist-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many-without-paylist-department.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedUpdateManyWithoutPaylist_departmentInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many-without-work-location.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many-without-work-location.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedUpdateManyWithoutWorkLocationInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-many.input.ts
@@ -84,4 +84,7 @@ export class PositionRequestUncheckedUpdateManyInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-without-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-without-department.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedUpdateWithoutDepartmentInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-without-parent-job-profile.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-without-parent-job-profile.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedUpdateWithoutParent_job_profileInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-without-paylist-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-without-paylist-department.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedUpdateWithoutPaylist_departmentInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-without-work-location.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update-without-work-location.input.ts
@@ -81,4 +81,7 @@ export class PositionRequestUncheckedUpdateWithoutWorkLocationInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-unchecked-update.input.ts
@@ -84,4 +84,7 @@ export class PositionRequestUncheckedUpdateInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-many-mutation.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-many-mutation.input.ts
@@ -69,4 +69,7 @@ export class PositionRequestUpdateManyMutationInput {
 
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
 }

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-without-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-without-department.input.ts
@@ -73,6 +73,9 @@ export class PositionRequestUpdateWithoutDepartmentInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => JobProfileUpdateOneWithoutPosition_requestNestedInput, { nullable: true })
   parent_job_profile?: JobProfileUpdateOneWithoutPosition_requestNestedInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-without-parent-job-profile.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-without-parent-job-profile.input.ts
@@ -73,6 +73,9 @@ export class PositionRequestUpdateWithoutParent_job_profileInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => DepartmentUpdateOneRequiredWithoutPositionRequestNestedInput, { nullable: true })
   department?: DepartmentUpdateOneRequiredWithoutPositionRequestNestedInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-without-paylist-department.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-without-paylist-department.input.ts
@@ -73,6 +73,9 @@ export class PositionRequestUpdateWithoutPaylist_departmentInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => JobProfileUpdateOneWithoutPosition_requestNestedInput, { nullable: true })
   parent_job_profile?: JobProfileUpdateOneWithoutPosition_requestNestedInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-without-work-location.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update-without-work-location.input.ts
@@ -73,6 +73,9 @@ export class PositionRequestUpdateWithoutWorkLocationInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => JobProfileUpdateOneWithoutPosition_requestNestedInput, { nullable: true })
   parent_job_profile?: JobProfileUpdateOneWithoutPosition_requestNestedInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-update.input.ts
@@ -74,6 +74,9 @@ export class PositionRequestUpdateInput {
   @Field(() => String, { nullable: true })
   additional_info_comments?: string;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info?: any;
+
   @Field(() => JobProfileUpdateOneWithoutPosition_requestNestedInput, { nullable: true })
   parent_job_profile?: JobProfileUpdateOneWithoutPosition_requestNestedInput;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-where-unique.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-where-unique.input.ts
@@ -102,6 +102,9 @@ export class PositionRequestWhereUniqueInput {
   @Field(() => StringFilter, { nullable: true })
   additional_info_comments?: StringFilter;
 
+  @Field(() => JsonFilter, { nullable: true })
+  additional_info?: JsonFilter;
+
   @Field(() => JobProfileRelationFilter, { nullable: true })
   parent_job_profile?: JobProfileRelationFilter;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-where.input.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request-where.input.ts
@@ -101,6 +101,9 @@ export class PositionRequestWhereInput {
   @Field(() => StringFilter, { nullable: true })
   additional_info_comments?: StringFilter;
 
+  @Field(() => JsonFilter, { nullable: true })
+  additional_info?: JsonFilter;
+
   @Field(() => JobProfileRelationFilter, { nullable: true })
   parent_job_profile?: JobProfileRelationFilter;
 

--- a/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request.model.ts
+++ b/apps/api/src/@generated/prisma-nestjs-graphql/position-request/position-request.model.ts
@@ -88,6 +88,9 @@ export class PositionRequest {
   @Field(() => String, { nullable: true })
   additional_info_comments!: string | null;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  additional_info!: any | null;
+
   @Field(() => JobProfile, { nullable: true })
   parent_job_profile?: JobProfile | null;
 

--- a/apps/api/src/modules/external/org-chart.service.ts
+++ b/apps/api/src/modules/external/org-chart.service.ts
@@ -24,8 +24,10 @@ export class OrgChartService {
     const departments = await this.departmentService.getDepartments();
 
     const positionsWithIncumbentsIds = (result?.data?.query?.rows ?? []).map((row) => row['A.POSITION_NBR']);
-    const employees: Map<string, Employee[]> =
-      await this.peoplesoftService.getEmployeesForPositions(positionsWithIncumbentsIds);
+
+    const employees: Map<string, Employee[]> = await this.peoplesoftService.getEmployeesForPositions(
+      process.env.TEST_ENV === 'true' ? ['00054971', '00100306'] : positionsWithIncumbentsIds,
+    );
 
     // Loop through response and generate the tree for everyone in the _current department_
     (result?.data?.query?.rows ?? []).forEach((position) => {

--- a/apps/app/src/components/app/common/contexts/position.context.tsx
+++ b/apps/app/src/components/app/common/contexts/position.context.tsx
@@ -94,9 +94,7 @@ export const PositionProvider: React.FC<PositionProviderProps> = ({ children }) 
                   // clear previous data
                   profile_json: null,
                   parent_job_profile: { connect: { id: null } },
-                  additional_info_comments: null,
-                  additional_info_excluded_mgr_position_number: null,
-                  paylist_department: { connect: { id: null } },
+                  additional_info: null,
                   title: null,
                 }).unwrap();
                 resolve(true);

--- a/apps/app/src/components/shared/download-job-profile/download-job-profile.component.tsx
+++ b/apps/app/src/components/shared/download-job-profile/download-job-profile.component.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { DownloadOutlined } from '@ant-design/icons';
-import { Button, Spin } from 'antd';
+import { DownloadOutlined, WarningFilled } from '@ant-design/icons';
+import { Button, Modal, Spin } from 'antd';
 import { generateJobProfile } from 'common-kit';
 import { Packer } from 'docx';
 import { saveAs } from 'file-saver';
@@ -12,6 +12,7 @@ export interface DownloadJobProfileComponentProps {
   style?: React.CSSProperties;
   ignoreAbsentParent?: boolean;
   renderTrigger?: (generate: () => void, isLoading: boolean) => React.ReactNode;
+  useModal?: boolean;
 }
 
 export const DownloadJobProfileComponent = ({
@@ -19,10 +20,12 @@ export const DownloadJobProfileComponent = ({
   jobProfile,
   style,
   ignoreAbsentParent = false,
+  useModal = false,
   renderTrigger,
 }: DownloadJobProfileComponentProps & React.PropsWithChildren & any) => {
   const [trigger, { data, isLoading }] = useLazyGetJobProfilesQuery();
   const [parentJobProfile, setParentJobProfile] = useState<Record<string, any> | null>(null);
+  const [isModalVisible, setIsModalVisible] = useState(false);
 
   useEffect(() => {
     if (jobProfile && !data) {
@@ -52,9 +55,82 @@ export const DownloadJobProfileComponent = ({
     }
   };
 
+  const handleCancel = () => {
+    setIsModalVisible(false);
+  };
+
+  const handleConfirm = () => {
+    setIsModalVisible(false);
+    generate(); // Call the generate function to download the file
+  };
+
   // Custom trigger rendering
   if (renderTrigger) {
     return <>{renderTrigger(generate, isLoading)}</>;
+  }
+
+  if (useModal) {
+    return children != null ? (
+      isLoading ? (
+        <Spin spinning={isLoading} />
+      ) : parentJobProfile == null ? (
+        <span>disabled</span>
+      ) : (
+        <>
+          <span onClick={() => setIsModalVisible(true)}>{children}</span>
+          <Modal
+            title={
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <WarningFilled style={{ color: 'orange', marginRight: '8px', fontSize: '1.5rem' }} />
+                Download profile
+              </div>
+            }
+            open={isModalVisible}
+            onOk={handleConfirm}
+            onCancel={handleCancel}
+            okText="Download profile"
+            cancelText="Cancel"
+          >
+            <p>
+              Please note that the profile you are about to download is an editable (.docx) version that has been
+              approved for recruitment purposes.
+            </p>
+            <p>Ensure that the content of the job profile remains unchanged.</p>
+          </Modal>
+        </>
+      )
+    ) : (
+      <>
+        <Button
+          style={style}
+          icon={<DownloadOutlined />}
+          loading={isLoading}
+          disabled={parentJobProfile == null && !ignoreAbsentParent}
+          onClick={() => setIsModalVisible(true)}
+        >
+          Download Job Profile
+        </Button>
+        <Modal
+          title={
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              <WarningFilled style={{ color: 'orange', marginRight: '8px', fontSize: '1.5rem' }} />
+              Download profile
+            </div>
+          }
+          open={isModalVisible}
+          onOk={handleConfirm}
+          onCancel={handleCancel}
+          okText="Download profile"
+          cancelText="Cancel"
+        >
+          <p>
+            Please note that the profile you are about to download is an editable (.docx) version that has been approved
+            for recruitment purposes.
+          </p>
+          <p>Ensure that the content of the job profile remains unchanged.</p>
+        </Modal>
+      </>
+    );
   }
 
   return children != null ? (

--- a/apps/app/src/redux/services/graphql-api/location.api.ts
+++ b/apps/app/src/redux/services/graphql-api/location.api.ts
@@ -39,7 +39,7 @@ export const locationApi = graphqlApi.injectEndpoints({
         };
       },
     }),
-    getLocation: build.query<GetLocationResponse, { id: string }>({
+    getLocation: build.query<GetLocationResponse, { id?: string }>({
       query: (args) => {
         return {
           document: gql`

--- a/apps/app/src/redux/services/graphql-api/position-request.api.ts
+++ b/apps/app/src/redux/services/graphql-api/position-request.api.ts
@@ -54,12 +54,18 @@ export interface GetPositionRequestResponseContent {
     number: number;
   };
 
-  additional_info_work_location_id?: string;
-  additional_info_department_id?: string;
-  additional_info_excluded_mgr_position_number?: string;
-  additional_info_comments?: string;
+  additional_info?: AdditionalInfo;
 
   crm_id?: string;
+}
+
+export interface AdditionalInfo {
+  work_location_id?: string;
+  department_id?: string;
+  excluded_mgr_position_number?: string;
+  comments?: string;
+  branch?: string;
+  division?: string;
 }
 
 export interface GetPositionRequestResponse {
@@ -117,19 +123,7 @@ export interface UpdatePositionRequestInput {
   classification_id?: string;
   submission_id?: string;
   status?: string;
-
-  workLocation?: {
-    connect: {
-      id: string;
-    };
-  };
-  paylist_department?: {
-    connect: {
-      id: string | null;
-    };
-  };
-  additional_info_excluded_mgr_position_number?: string | null;
-  additional_info_comments?: string | null;
+  additional_info?: AdditionalInfo | null;
   parent_job_profile?: {
     connect: {
       id: number | null;
@@ -284,10 +278,7 @@ export const positionRequestApi = graphqlApi.injectEndpoints({
                   parent_job_profile {
                     number
                   }
-                  additional_info_work_location_id
-                  additional_info_department_id
-                  additional_info_excluded_mgr_position_number
-                  additional_info_comments
+                  additional_info
                   crm_id
                   shareUUID
               }
@@ -327,10 +318,7 @@ export const positionRequestApi = graphqlApi.injectEndpoints({
                   parent_job_profile {
                     number
                   }
-                  additional_info_work_location_id
-                  additional_info_department_id
-                  additional_info_excluded_mgr_position_number
-                  additional_info_comments
+                  additional_info
                   crm_id
               }
           }

--- a/apps/app/src/routes/classification-tasks/components/service-request-details.component.tsx
+++ b/apps/app/src/routes/classification-tasks/components/service-request-details.component.tsx
@@ -3,10 +3,13 @@ import { Card, Col, Descriptions, Row } from 'antd';
 import LoadingComponent from '../../../components/app/common/components/loading.component';
 import PositionProfile from '../../../components/app/common/components/positionProfile';
 import { useGetLocationQuery } from '../../../redux/services/graphql-api/location.api';
+import { GetPositionRequestResponseContent } from '../../../redux/services/graphql-api/position-request.api';
 import { formatDateTime } from '../../../utils/Utils';
 
 type ServiceRequestDetailsProps = {
-  positionRequestData: any;
+  positionRequestData: {
+    positionRequest: GetPositionRequestResponseContent | null;
+  };
 };
 
 export const ServiceRequestDetails: React.FC<ServiceRequestDetailsProps> = ({ positionRequestData }) => {
@@ -14,9 +17,9 @@ export const ServiceRequestDetails: React.FC<ServiceRequestDetailsProps> = ({ po
 
   const { data: locationInfo, isLoading: locationLoading } = useGetLocationQuery(
     {
-      id: positionRequestData?.positionRequest?.additional_info_work_location_id,
+      id: positionRequestData?.positionRequest?.additional_info?.work_location_id,
     },
-    { skip: !positionRequestData?.positionRequest?.additional_info_work_location_id },
+    { skip: !positionRequestData?.positionRequest?.additional_info?.work_location_id },
   );
 
   // console.log('locationInfo: ', locationInfo);
@@ -31,7 +34,12 @@ export const ServiceRequestDetails: React.FC<ServiceRequestDetailsProps> = ({ po
     {
       key: 'submittedAt',
       label: 'Submitted at',
-      children: <div>{formatDateTime(positionRequestData?.positionRequest?.approved_at)}</div>,
+      children: (
+        <div>
+          {positionRequestData?.positionRequest?.approved_at &&
+            formatDateTime(positionRequestData?.positionRequest?.approved_at)}
+        </div>
+      ),
       span: { xs: 24, sm: 24, md: 24, lg: 12, xl: 12 },
     },
     {
@@ -91,7 +99,7 @@ export const ServiceRequestDetails: React.FC<ServiceRequestDetailsProps> = ({ po
       label: 'Reports to',
       children: (
         <PositionProfile
-          positionNumber={positionRequestData?.positionRequest?.additional_info_excluded_mgr_position_number}
+          positionNumber={positionRequestData?.positionRequest?.additional_info?.excluded_mgr_position_number}
           orgChartData={positionRequestData?.positionRequest?.orgchart_json}
         ></PositionProfile>
         // <div>
@@ -147,7 +155,19 @@ export const ServiceRequestDetails: React.FC<ServiceRequestDetailsProps> = ({ po
     {
       key: 'payListDepartmentIdNumber',
       label: 'Department ID',
-      children: <div>{positionRequestData?.positionRequest?.additional_info_department_id}</div>,
+      children: <div>{positionRequestData?.positionRequest?.additional_info?.department_id}</div>,
+      span: { xs: 24, sm: 24, md: 24, lg: 24, xl: 24 },
+    },
+    {
+      key: 'branch',
+      label: 'Branch',
+      children: <div>{positionRequestData?.positionRequest?.additional_info?.branch}</div>,
+      span: { xs: 24, sm: 24, md: 24, lg: 24, xl: 24 },
+    },
+    {
+      key: 'division',
+      label: 'Division',
+      children: <div>{positionRequestData?.positionRequest?.additional_info?.division}</div>,
       span: { xs: 24, sm: 24, md: 24, lg: 24, xl: 24 },
     },
     {

--- a/apps/app/src/routes/total-comp-approved-requests/total-comp-approved-request.page.tsx
+++ b/apps/app/src/routes/total-comp-approved-requests/total-comp-approved-request.page.tsx
@@ -85,7 +85,7 @@ export const TotalCompApprovedRequestPage = () => {
       label: 'Reports to',
       children: (
         <div>
-          Hill, Nathan CITZ:EX <br />
+          TEST DATA Hill, Nathan CITZ:EX <br />
           Sr. Director, Digital Portfolio, Band 4 <br />
           Position No.: 00012345
         </div>
@@ -97,7 +97,7 @@ export const TotalCompApprovedRequestPage = () => {
       label: 'First level excluded manager for this position',
       children: (
         <div>
-          Hill, Nathan CITZ:EX <br />
+          TEST DATA Hill, Nathan CITZ:EX <br />
           Sr. Director, Digital Portfolio, Band 4 <br />
           Position No.: 00012345
         </div>
@@ -107,7 +107,19 @@ export const TotalCompApprovedRequestPage = () => {
     {
       key: 'payListDepartmentIdNumber',
       label: 'Department ID',
-      children: <div>{data?.positionRequest?.additional_info_department_id}</div>,
+      children: <div>{data?.positionRequest?.additional_info?.department_id}</div>,
+      span: { xs: 24, sm: 24, md: 24, lg: 24, xl: 24 },
+    },
+    {
+      key: 'branch',
+      label: 'Branch',
+      children: <div>{data?.positionRequest?.additional_info?.branch}</div>,
+      span: { xs: 24, sm: 24, md: 24, lg: 24, xl: 24 },
+    },
+    {
+      key: 'division',
+      label: 'Division',
+      children: <div>{data?.positionRequest?.additional_info?.division}</div>,
       span: { xs: 24, sm: 24, md: 24, lg: 24, xl: 24 },
     },
     {
@@ -269,7 +281,6 @@ export const TotalCompApprovedRequestPage = () => {
       label: 'Organization Chart',
       children: (
         <div style={{ height: '100%' }}>
-          {/* <OrgChartWrapped selectedDepartment={data?.positionRequest?.additional_info_department_id ?? null} /> */}
           <OrgChart
             type={OrgChartType.READONLY}
             departmentId={data?.positionRequest?.department_id ?? ''}

--- a/apps/app/src/routes/wizard/components/wizard-edit-profile.tsx
+++ b/apps/app/src/routes/wizard/components/wizard-edit-profile.tsx
@@ -205,7 +205,7 @@ const WizardEditProfile = forwardRef(
     }, [classificationsData, classificationsDataIsLoading, receivedClassificationsDataCallback]);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { control, reset, handleSubmit, getValues, formState, trigger, watch } = useForm<JobProfileValidationModel>({
+    const { control, reset, handleSubmit, getValues, formState, trigger } = useForm<JobProfileValidationModel>({
       resolver: classValidatorResolver(JobProfileValidationModel),
       mode: 'onChange',
     });

--- a/apps/app/src/routes/wizard/position-request.page.tsx
+++ b/apps/app/src/routes/wizard/position-request.page.tsx
@@ -502,7 +502,10 @@ export const PositionRequestPage = () => {
                               <Button type="link">View</Button> | <Button type="link">Download</Button>
                             </Descriptions.Item> */}
                             <Descriptions.Item label="Job profile">
-                              <DownloadJobProfileComponent jobProfile={unwrappedPositionRequestData?.profile_json}>
+                              <DownloadJobProfileComponent
+                                jobProfile={unwrappedPositionRequestData?.profile_json}
+                                useModal={true}
+                              >
                                 <a href="#">Download</a>
                               </DownloadJobProfileComponent>
                             </Descriptions.Item>

--- a/apps/app/src/routes/wizard/wizard-confirm-details.page.tsx
+++ b/apps/app/src/routes/wizard/wizard-confirm-details.page.tsx
@@ -88,6 +88,12 @@ export class WizardConfirmDetailsModel {
   @IsNotEmpty({ message: 'Department ID is required' })
   payListDepartmentId: string | null;
 
+  @IsNotEmpty({ message: 'Branch is required' })
+  branch: string;
+
+  @IsNotEmpty({ message: 'Division is required' })
+  division: string;
+
   // Validate only if the field is not empty
   // @ValidateIf((o) => o.excludedManagerPositionNumber !== '')
   // @Validate(PositionValidator, {
@@ -186,10 +192,10 @@ export const WizardConfirmDetailsPage: React.FC<WizardConfirmPageProps> = ({
   // get profile info for excluded manager from additional_info_excluded_mgr_position_number using GetPositionProfileQuery and useEffect
   useEffect(() => {
     async function fetchExcludedManagerProfile() {
-      if (positionRequestData?.additional_info_excluded_mgr_position_number) {
+      if (positionRequestData?.additional_info?.excluded_mgr_position_number) {
         try {
           await getPositionProfile({
-            positionNumber: positionRequestData.additional_info_excluded_mgr_position_number,
+            positionNumber: positionRequestData.additional_info.excluded_mgr_position_number,
             uniqueKey: 'excludedManagerProfile',
             suppressGlobalError: true,
           }).unwrap();
@@ -199,7 +205,7 @@ export const WizardConfirmDetailsPage: React.FC<WizardConfirmPageProps> = ({
       }
     }
     fetchExcludedManagerProfile();
-  }, [positionRequestData?.additional_info_excluded_mgr_position_number, getPositionProfile]);
+  }, [positionRequestData?.additional_info?.excluded_mgr_position_number, getPositionProfile]);
 
   const { data: allLocations } = useGetLocationsQuery();
 
@@ -294,10 +300,14 @@ export const WizardConfirmDetailsPage: React.FC<WizardConfirmPageProps> = ({
           // position_number: 123456,
 
           // attach additional information
-          workLocation: { connect: { id: formData.workLocation || '' } },
-          paylist_department: { connect: { id: formData.payListDepartmentId || '' } },
-          additional_info_excluded_mgr_position_number: formData.excludedManagerPositionNumber,
-          additional_info_comments: formData.comments,
+          additional_info: {
+            department_id: formData.payListDepartmentId ?? undefined,
+            work_location_id: formData.workLocation ?? undefined,
+            excluded_mgr_position_number: formData.excludedManagerPositionNumber,
+            comments: formData.comments,
+            branch: formData.branch,
+            division: formData.division,
+          },
         }).unwrap();
         if (onNext && updateStep) onNext();
       } else {
@@ -341,24 +351,26 @@ export const WizardConfirmDetailsPage: React.FC<WizardConfirmPageProps> = ({
       excludedManagerPositionNumber: '',
       payListDepartmentId: null as string | null,
       comments: '',
+      branch: '',
+      division: '',
     },
   });
 
   useEffect(() => {
     if (positionRequestData) {
-      const {
-        additional_info_work_location_id,
-        additional_info_department_id,
-        additional_info_excluded_mgr_position_number,
-        additional_info_comments,
-      } = positionRequestData;
+      const { work_location_id, department_id, excluded_mgr_position_number, comments, branch, division } =
+        positionRequestData.additional_info ?? {};
+
+      setValue('branch', branch || '');
+      setValue('division', division || '');
+
       setValue(
         'workLocation',
-        additional_info_work_location_id ||
+        work_location_id ||
           departmentsData?.find((dept) => dept.id === positionRequestData?.department_id)?.location_id ||
           null,
       );
-      setValue('payListDepartmentId', additional_info_department_id || positionRequestData?.department_id || null);
+      setValue('payListDepartmentId', department_id || positionRequestData?.department_id || null);
 
       const { orgchart_json, reports_to_position_id } = positionRequest ?? {
         orgchart_json: undefined,
@@ -371,19 +383,14 @@ export const WizardConfirmDetailsPage: React.FC<WizardConfirmPageProps> = ({
           ? findExcludedManager(`${reports_to_position_id}`, orgchart_json)
           : undefined;
 
-      setValue('excludedManagerPositionNumber', additional_info_excluded_mgr_position_number || lookup?.id || '');
+      setValue('excludedManagerPositionNumber', excluded_mgr_position_number || lookup?.id || '');
       if (lookup?.id) {
         debouncedFetchPositionProfile(lookup.id);
       }
 
-      setValue('comments', additional_info_comments || '');
+      setValue('comments', comments || '');
 
-      if (
-        additional_info_work_location_id ||
-        additional_info_department_id ||
-        additional_info_excluded_mgr_position_number ||
-        additional_info_comments
-      ) {
+      if (work_location_id || department_id || excluded_mgr_position_number || comments || branch || division) {
         setValue('confirmation', true);
       }
     }
@@ -692,6 +699,47 @@ export const WizardConfirmDetailsPage: React.FC<WizardConfirmPageProps> = ({
                               <LoadingSpinnerWithMessage data-testid="loading-spinner" mode="small" />
                             )}
                           </div>
+                        </Col>
+                      </Row>
+                    </Card>
+
+                    <Card
+                      title={
+                        <span id="excluded-manager-id-label">
+                          <h3 style={{ fontWeight: '600', fontSize: '16px' }}>Branch and Division</h3>
+                        </span>
+                      }
+                      bordered={false}
+                      className="custom-card"
+                      style={{ marginTop: 16 }}
+                    >
+                      <Row justify="start">
+                        <Col xs={24} sm={24} md={24} lg={18} xl={12}>
+                          <Form.Item
+                            name="branch"
+                            label="Branch"
+                            validateStatus={errors.branch ? 'error' : ''}
+                            help={errors.branch?.message}
+                          >
+                            <Controller
+                              name="branch"
+                              control={control}
+                              render={({ field }) => <Input {...field} disabled={!confirmation} />}
+                            />
+                          </Form.Item>
+
+                          <Form.Item
+                            name="division"
+                            label="Division"
+                            validateStatus={errors.division ? 'error' : ''}
+                            help={errors.division?.message}
+                          >
+                            <Controller
+                              name="division"
+                              control={control}
+                              render={({ field }) => <Input {...field} disabled={!confirmation} />}
+                            />
+                          </Form.Item>
                         </Col>
                       </Row>
                     </Card>

--- a/apps/app/src/routes/wizard/wizard-result.page.tsx
+++ b/apps/app/src/routes/wizard/wizard-result.page.tsx
@@ -89,8 +89,8 @@ export const WizardResultPage: React.FC<WizardResultPageProps> = ({
     if (positionRequestLoading || positionNeedsRivewLoading) return;
 
     // load comment if prevsiously entered
-    if (positionRequestData?.positionRequest?.additional_info_comments) {
-      setComment(positionRequestData.positionRequest.additional_info_comments);
+    if (positionRequestData?.positionRequest?.additional_info?.comments) {
+      setComment(positionRequestData.positionRequest?.additional_info.comments);
     }
 
     // if state is draft and position doesn't need review, set mode to readyToCreatePositionNumber
@@ -338,7 +338,7 @@ export const WizardResultPage: React.FC<WizardResultPageProps> = ({
                 <Row justify="center" style={{ padding: '0 1rem' }}>
                   <Col xs={24} md={24} lg={24} xl={14} xxl={18}>
                     <Alert
-                      description="You have completed your profile. At this point, it is saved as draft. You may ask others to review by sending them a link, or you may proceed to generating a position number. If there have been changes to significant accountabilities, we will seamlessly create a position review for classification and exclusion services."
+                      description="You have completed your profile. At this point, it is saved as draft. You may proceed to generate the position number."
                       type="info"
                       showIcon
                     />


### PR DESCRIPTION
AL-620 HM: Add ‘Division’ and ‘Branch’ fields to the 'Additional details' page AL-621 The banner text on the actions page when the ticket is in ‘Ready’ state needs to be updated. AL-631 'Reset changes' button populates wrong data AL-622 Add a reminder for users to refrain from making any changes to the approved profile during recruitment.