### PR TITLE
fix for additional details not retaining data if you go back

### DIFF
--- a/apps/api/src/modules/position-request/position-request.service.ts
+++ b/apps/api/src/modules/position-request/position-request.service.ts
@@ -945,9 +945,9 @@ export class PositionRequestApiService {
       if (additionalInfo.comments !== undefined) {
         (updatePayload.additional_info as Record<string, Prisma.JsonValue>).comments = additionalInfo.comments;
       }
-    } else if (additionalInfo == null) {
+    } else if (additionalInfo === null) {
       updatingAdditionalInfo = true;
-      updatePayload.additional_info = null;
+      updatePayload.additional_info = Prisma.DbNull;
     }
 
     if (!updatingAdditionalInfo) delete updatePayload.additional_info;


### PR DESCRIPTION
AL-644 'Additional details' does not retain user defined data if they go back a step