### PR TITLE
updated notes for restore

### DIFF
--- a/deployments/openshift/kustomize/base/crunchy/postgrescluster.yml
+++ b/deployments/openshift/kustomize/base/crunchy/postgrescluster.yml
@@ -1,7 +1,7 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  name: api-postgres-alpha
+  name: api-postgres-clone
 spec:
   instances:
     - replicas: 2


### PR DESCRIPTION
also changed name of default postgres cluster to clone, to reduce risk of deleting production instances.