### PR TITLE
Wizard improvements

### DIFF
--- a/apps/app/src/routes/wizard/components/wizard-steps.component.css
+++ b/apps/app/src/routes/wizard/components/wizard-steps.component.css
@@ -24,6 +24,14 @@
   color: rgba(0, 0, 0, 0.88);
 }
 
+.custom-steps.max-step-2 .ant-steps-item:nth-child(2) .ant-steps-item-description,
+.custom-steps.max-step-3 .ant-steps-item:nth-child(3) .ant-steps-item-description,
+.custom-steps.max-step-4 .ant-steps-item:nth-child(4) .ant-steps-item-description,
+.custom-steps.max-step-5 .ant-steps-item:nth-child(5) .ant-steps-item-description
+{
+  color: #4e4e4e;
+}
+
 .custom-steps .clickable:not(.no-click):hover *{
   cursor: pointer !important;
   color: #3470B1 !important;
@@ -34,22 +42,21 @@
 }
 
 
+.custom-steps.max-step-2 .ant-steps-item:nth-child(1):not(.ant-steps-item-finish) .ant-steps-item-tail::after,
+.custom-steps.max-step-2 .ant-steps-item:nth-child(1):not(.ant-steps-item-active):not(.ant-steps-item-finish) .ant-steps-icon-dot,
+.custom-steps.max-step-2 .ant-steps-item:nth-child(2):not(.ant-steps-item-active):not(.ant-steps-item-finish) .ant-steps-icon-dot,
 
-.custom-steps.max-step-2 .ant-steps-item:nth-child(1) .ant-steps-item-tail::after,
-.custom-steps.max-step-2 .ant-steps-item:nth-child(1):not(.ant-steps-item-active) .ant-steps-icon-dot,
-.custom-steps.max-step-2 .ant-steps-item:nth-child(2):not(.ant-steps-item-active) .ant-steps-icon-dot,
+.custom-steps.max-step-3 .ant-steps-item:nth-child(2):not(.ant-steps-item-finish) .ant-steps-item-tail::after,
+.custom-steps.max-step-3 .ant-steps-item:nth-child(3):not(.ant-steps-item-active):not(.ant-steps-item-finish) .ant-steps-icon-dot,
 
-.custom-steps.max-step-3 .ant-steps-item:nth-child(2) .ant-steps-item-tail::after,
-.custom-steps.max-step-3 .ant-steps-item:nth-child(3):not(.ant-steps-item-active) .ant-steps-icon-dot,
+.custom-steps.max-step-4 .ant-steps-item:nth-child(3):not(.ant-steps-item-finish) .ant-steps-item-tail::after,
+.custom-steps.max-step-4 .ant-steps-item:nth-child(4):not(.ant-steps-item-active):not(.ant-steps-item-finish) .ant-steps-icon-dot,
 
-.custom-steps.max-step-4 .ant-steps-item:nth-child(3) .ant-steps-item-tail::after,
-.custom-steps.max-step-4 .ant-steps-item:nth-child(4):not(.ant-steps-item-active) .ant-steps-icon-dot,
+.custom-steps.max-step-5 .ant-steps-item:nth-child(4):not(.ant-steps-item-finish) .ant-steps-item-tail::after,
+.custom-steps.max-step-5 .ant-steps-item:nth-child(5):not(.ant-steps-item-active):not(.ant-steps-item-finish) .ant-steps-icon-dot,
 
-.custom-steps.max-step-5 .ant-steps-item:nth-child(4) .ant-steps-item-tail::after,
-.custom-steps.max-step-5 .ant-steps-item:nth-child(5):not(.ant-steps-item-active) .ant-steps-icon-dot,
-
-.custom-steps.max-step-6 .ant-steps-item:nth-child(5) .ant-steps-item-tail::after,
-.custom-steps.max-step-6 .ant-steps-item:nth-child(6):not(.ant-steps-item-active) .ant-steps-icon-dot
+.custom-steps.max-step-6 .ant-steps-item:nth-child(5):not(.ant-steps-item-finish) .ant-steps-item-tail::after,
+.custom-steps.max-step-6 .ant-steps-item:nth-child(6):not(.ant-steps-item-active):not(.ant-steps-item-finish) .ant-steps-icon-dot
 {
   background-color: #A8D0FB !important;
 }
@@ -60,3 +67,15 @@
 
 
 
+/* .custom-steps .ant-steps-item-finish .ant-steps-item-tail::after {
+  background-color: #1890FF !important;
+}
+
+.custom-steps .ant-steps-item:not(.ant-steps-item-active):not(.ant-steps-item-finish) .ant-steps-icon-dot {
+  background-color: #A8D0FB !important;
+} */
+
+/* .custom-steps .ant-steps-item:not(.ant-steps-item-finish) .ant-steps-item-tail::after, 
+.custom-steps .ant-steps-item:not(.ant-steps-item-active):not(.ant-steps-item-finish) .ant-steps-icon-dot  {
+  background-color: #A8D0FB !important;
+} */

--- a/apps/app/src/routes/wizard/components/wizard-steps.component.tsx
+++ b/apps/app/src/routes/wizard/components/wizard-steps.component.tsx
@@ -13,7 +13,7 @@ interface WizardStepsProps {
 
 export const WizardSteps: React.FC<WizardStepsProps> = ({
   current,
-  xl = 14,
+  xl = 16,
   maxStepCompleted = 0,
   onStepClick,
   disabledTooltip,

--- a/apps/app/src/routes/wizard/wizard-org-chart.page.tsx
+++ b/apps/app/src/routes/wizard/wizard-org-chart.page.tsx
@@ -182,7 +182,7 @@ export const WizardOrgChartPage = ({
             }}
             loading={isLoading}
           >
-            Next
+            Save and next
           </Button>
         </Tooltip>,
       ]}


### PR DESCRIPTION
Feedback recommendations:

- The current and previous steps (1 Org chart, 2 choose profile, and 3 edit) should be marked with the darker blue to signify that they are complete
- The completed following step (4 review) should be in the lighter blue (it is correct in prod ✅). This color difference is to suggest that a completed following step could lose data if changes are made in the current step.
- Could you change the sub text of the current step to a darker grey #4e4e4e?
- Could you also increase the space between each step? 'Edit' and 'Review' looks a bit cramped. You can increase the overall width of the wizard as it looks like we have a lot of left and right padding that could be used
- Could we change the CTA from 'Next' to 'Save and Next' since we now save the request from here (org chart)