### PR TITLE
Remove wizard context from job profiles

### DIFF
--- a/apps/app/src/routes/job-profiles/components/job-profiles.component.tsx
+++ b/apps/app/src/routes/job-profiles/components/job-profiles.component.tsx
@@ -10,7 +10,6 @@ import { GetJobProfilesResponse, JobProfileModel } from '../../../redux/services
 import { useLazyGetJobProfilesQuery } from '../../../redux/services/graphql-api/job-profile.api';
 import { OrganizationModel } from '../../../redux/services/graphql-api/organization';
 import { useLazyGetPositionQuery } from '../../../redux/services/graphql-api/position.api';
-import { WizardProvider, useWizardContext } from '../../wizard/components/wizard.provider';
 import { JobProfileSearchResults } from './job-profile-search-results.component';
 import { JobProfileSearch } from './job-profile-search.component';
 import { JobProfile } from './job-profile.component';
@@ -29,6 +28,7 @@ interface JobProfilesContentProps {
   organizationFilterExtra?: OrganizationModel;
   positionRequestId?: number;
   loadProfileIds?: number[];
+  prData?: any;
 }
 
 interface JobProfilesRef {
@@ -44,6 +44,7 @@ const JobProfiles = forwardRef<JobProfilesRef, JobProfilesContentProps>(
       previousSearchState,
       organizationFilterExtra,
       loadProfileIds,
+      prData,
       page_size = 10,
     },
     ref,
@@ -59,7 +60,6 @@ const JobProfiles = forwardRef<JobProfilesRef, JobProfilesContentProps>(
     const { positionRequestId, number } = useParams();
     const params = useParams();
     const screens: Partial<Record<Breakpoint, boolean>> = useBreakpoint();
-    const { positionRequestData: prData } = useWizardContext();
 
     // useref to keep track of whether we fetched with selectProfileId
     const selectProfileIdRan = useRef(false);
@@ -436,48 +436,46 @@ const JobProfiles = forwardRef<JobProfilesRef, JobProfilesContentProps>(
 
     return (
       <>
-        <WizardProvider>
-          <JobProfileSearch
-            fullWidth={true}
-            positionRequestId={positionRequestId ? parseInt(positionRequestId) : undefined}
-            ministriesData={ministriesData}
-          />
-          <Row justify="center" gutter={16}>
-            {screens['xl'] === true ? (
-              <>
-                <Col span={8}>
-                  <JobProfileSearchResults
-                    data={useData}
-                    //  jobProfilesLoading || isLoading
-                    isLoading={useData == null || positionFilteringProcessActive}
-                    onSelectProfile={onSelectProfile}
-                    currentPage={currentPage}
-                    pageSize={pageSize}
-                    totalResults={totalResults}
-                    onPageChange={handlePageChange}
-                  />{' '}
-                </Col>
-                <Col span={16} role="region" aria-label="Selected job profile contents">
-                  {renderJobProfile()}
-                </Col>
-              </>
-            ) : params.id ? (
-              <Col span={24} role="region" aria-label="Selected job profile contents">
+        <JobProfileSearch
+          fullWidth={true}
+          positionRequestId={positionRequestId ? parseInt(positionRequestId) : undefined}
+          ministriesData={ministriesData}
+        />
+        <Row justify="center" gutter={16}>
+          {screens['xl'] === true ? (
+            <>
+              <Col span={8}>
+                <JobProfileSearchResults
+                  data={useData}
+                  //  jobProfilesLoading || isLoading
+                  isLoading={useData == null || positionFilteringProcessActive}
+                  onSelectProfile={onSelectProfile}
+                  currentPage={currentPage}
+                  pageSize={pageSize}
+                  totalResults={totalResults}
+                  onPageChange={handlePageChange}
+                />{' '}
+              </Col>
+              <Col span={16} role="region" aria-label="Selected job profile contents">
                 {renderJobProfile()}
               </Col>
-            ) : (
-              <JobProfileSearchResults
-                data={useData}
-                isLoading={isLoading}
-                onSelectProfile={onSelectProfile}
-                currentPage={currentPage}
-                pageSize={pageSize}
-                totalResults={totalResults}
-                onPageChange={handlePageChange}
-              />
-            )}
-          </Row>
-        </WizardProvider>
+            </>
+          ) : params.id ? (
+            <Col span={24} role="region" aria-label="Selected job profile contents">
+              {renderJobProfile()}
+            </Col>
+          ) : (
+            <JobProfileSearchResults
+              data={useData}
+              isLoading={isLoading}
+              onSelectProfile={onSelectProfile}
+              currentPage={currentPage}
+              pageSize={pageSize}
+              totalResults={totalResults}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </Row>
       </>
     );
   },

--- a/apps/app/src/routes/job-profiles/components/job-profiles.component.tsx
+++ b/apps/app/src/routes/job-profiles/components/job-profiles.component.tsx
@@ -359,9 +359,9 @@ const JobProfiles = forwardRef<JobProfilesRef, JobProfilesContentProps>(
           setCurrentPage(newPage);
           searchParams.set('page', newPage.toString());
           // if we are on /job-profiles route, don't set "selectedProfile"
-          if (!location.pathname.startsWith('/job-profiles')) {
-            searchParams.set('selectedProfile', selectProfileNumber ?? '');
-          }
+          // if (!location.pathname.startsWith('/job-profiles')) {
+          searchParams.set('selectedProfile', selectProfileNumber ?? '');
+          // }
 
           const basePath = location.pathname.startsWith('/job-profiles')
             ? location.pathname

--- a/apps/app/src/routes/job-profiles/job-profiles.page.tsx
+++ b/apps/app/src/routes/job-profiles/job-profiles.page.tsx
@@ -17,7 +17,12 @@ export const JobProfilesPage = () => {
       />
       {/* <div style={{ padding: '0 1rem' }}> */}
       <ContentWrapper>
-        <JobProfiles searchParams={searchParams} page_size={page_size} selectProfileNumber={number} />
+        <JobProfiles
+          key={'SearchProfiles'}
+          searchParams={searchParams}
+          page_size={page_size}
+          selectProfileNumber={number}
+        />
       </ContentWrapper>
       {/* </div> */}
       {/* </Space> */}

--- a/apps/app/src/routes/job-profiles/saved-job-profiles.page.tsx
+++ b/apps/app/src/routes/job-profiles/saved-job-profiles.page.tsx
@@ -22,7 +22,11 @@ export const SavedJobProfilesPage = () => {
     <>
       <PageHeader title="Saved profiles" />
       <ContentWrapper>
-        <JobProfiles searchParams={searchParams} loadProfileIds={savedJobProfileIds?.getSavedJobProfileIds} />
+        <JobProfiles
+          key={'SavedProfiles'}
+          searchParams={searchParams}
+          loadProfileIds={savedJobProfileIds?.getSavedJobProfileIds}
+        />
       </ContentWrapper>
     </>
   );

--- a/apps/app/src/routes/wizard/wizard.page.tsx
+++ b/apps/app/src/routes/wizard/wizard.page.tsx
@@ -392,6 +392,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
         }}
       >
         <JobProfiles
+          key={'WizardProfiles'}
           ref={jobProfileSearchResultsRef}
           searchParams={searchParams}
           onSelectProfile={onSelectProfile}
@@ -400,6 +401,7 @@ export const WizardPage: React.FC<WizardPageProps> = ({
           previousSearchState={previousSearchState}
           // this will filter job profiles by organization in which this position is being created in
           organizationFilterExtra={departmentData?.department?.organization}
+          prData={positionRequestData}
         />
       </div>
     </WizardPageWrapper>


### PR DESCRIPTION
removed the wizard context so its not kept when switching from wizard to explore or save job profiles. This was causing profile results to be filtered by position request data.