### PR TITLE
bug fixes

### DIFF
--- a/apps/api/src/modules/job-profile/job-profile.service.ts
+++ b/apps/api/src/modules/job-profile/job-profile.service.ts
@@ -1331,6 +1331,7 @@ export class JobProfileService {
     let jobProfiles = await this.prisma.jobProfile.findMany({
       where: {
         AND: [
+          { current_version: true },
           { id: { not: excludeProfileId ?? -1 } },
           {
             OR: [

--- a/apps/app/src/routes/job-profiles/components/job-profile.component.tsx
+++ b/apps/app/src/routes/job-profiles/components/job-profile.component.tsx
@@ -911,7 +911,9 @@ export const JobProfile: React.FC<JobProfileProps> = ({
                 (effectiveData?.professional_registration_requirements?.filter((ed) => !ed.disabled)?.length ?? 0) >
                   0)) && (
               <>
-                <h4>Professional registration and certification requirements</h4>
+                {(effectiveData?.professional_registration_requirements?.filter(
+                  (ed) => !ed.disabled && ed.is_significant,
+                )?.length ?? 0) > 0 && <h4>Professional registration and certification requirements</h4>}
 
                 <>
                   <ul data-testid="professional-registration">
@@ -1045,8 +1047,8 @@ export const JobProfile: React.FC<JobProfileProps> = ({
             {((showDiff && (effectiveData?.security_screenings?.length ?? 0) > 0) ||
               (!showDiff && (effectiveData?.security_screenings.filter((ed) => !ed.disabled)?.length ?? 0) > 0)) && (
               <>
-                <h4>Security screenings</h4>
-
+                {(effectiveData?.security_screenings.filter((ed) => !ed.disabled && ed.is_significant)?.length ?? 0) >
+                  0 && <h4>Security screenings</h4>}
                 <>
                   {/* Main - is_significant == true */}
                   <ul data-testid="security-screenings">

--- a/apps/app/src/routes/total-comp-create-profile/components/total-comp-create-profile.component.tsx
+++ b/apps/app/src/routes/total-comp-create-profile/components/total-comp-create-profile.component.tsx
@@ -3496,7 +3496,6 @@ export const TotalCompCreateProfileComponent: React.FC<TotalCompCreateProfileCom
                                     addAction={appendProfessionalRegistrationRequirement}
                                     removeAction={removeProfessionalRegistrationRequirement}
                                     triggerValidation={triggerProfileValidation}
-                                    markAllSignificantProReg={markAllSignificantProReg}
                                   />
                                 </Col>
                                 <Col>
@@ -4100,6 +4099,7 @@ export const TotalCompCreateProfileComponent: React.FC<TotalCompCreateProfileCom
                                     triggerValidation={triggerProfileValidation}
                                     title="Security screenings"
                                     buttonText="Browse and add security screenings"
+                                    addAsSignificantAndReadonly={true}
                                   />
                                 </Col>
                                 <Col>

--- a/apps/app/src/routes/wizard/components/wizard-edit-profile-list-item.tsx
+++ b/apps/app/src/routes/wizard/components/wizard-edit-profile-list-item.tsx
@@ -2,7 +2,7 @@
 import { Input, List, Typography } from 'antd';
 import TextArea from 'antd/es/input/TextArea';
 import debounce from 'lodash.debounce';
-import { Controller, UseFieldArrayRemove, UseFieldArrayUpdate, UseFormReturn, UseFormTrigger } from 'react-hook-form';
+import { Controller, UseFieldArrayRemove, UseFormReturn, UseFormTrigger } from 'react-hook-form';
 import { FormItem } from '../../../utils/FormItem';
 import { JobProfileValidationModel } from '../../job-profiles/components/job-profile.component';
 import { ContextOptions } from './context-options.component';
@@ -38,7 +38,6 @@ interface FieldItemProps {
   onFocus?: () => void;
   originalFields?: any[];
   isAdmin?: boolean | undefined;
-  update?: UseFieldArrayUpdate<any, string>;
   remove?: UseFieldArrayRemove;
   fields?: Record<'id', string>[];
   trigger?: UseFormTrigger<JobProfileValidationModel>;
@@ -61,7 +60,6 @@ const WizardEditProfileListItem: React.FC<FieldItemProps> = ({
   onFocus,
   originalFields,
   isAdmin = undefined,
-  update,
 }) => {
   const ariaLabel = field.disabled
     ? `Undo remove ${label ?? fieldName} ${index + 1}`
@@ -76,6 +74,12 @@ const WizardEditProfileListItem: React.FC<FieldItemProps> = ({
       setEditedFields((prev) => ({ ...prev, [index]: updatedValue !== originalFields?.[index]?.['text'] }));
     useFormReturn.trigger();
   }, 300);
+
+  // let debug = false;
+  // if (field.text.startsWith('editable, sig')) {
+  //   console.log('field: ', field);
+  //   debug = true;
+  // }
 
   return (
     <List.Item
@@ -115,6 +119,9 @@ const WizardEditProfileListItem: React.FC<FieldItemProps> = ({
         control={useFormReturn.control}
         name={`${fieldName}.${index}.text`}
         render={({ field: { onChange, onBlur, value } }) => {
+          // if (debug) {
+          //   console.log('field: ', field, value);
+          // }
           // if (fieldName === 'accountabilities') console.log('field: ', field);
 
           return (
@@ -152,11 +159,16 @@ const WizardEditProfileListItem: React.FC<FieldItemProps> = ({
                       // onChange(originalFields?.[index]?.['text']);
                       setEditedFields && setEditedFields((prev) => ({ ...prev, [index]: true }));
                       // set disabled to true
-                      update?.(index, {
-                        ...field,
-                        text: originalFields?.[index]?.['text'],
-                        disabled: true,
-                      });
+
+                      // update for some reason doesn't update the value in the text box
+                      // update?.(index, {
+                      //   ...field,
+                      //   text: originalFields?.[index]?.['text'],
+                      //   disabled: true,
+                      // });
+
+                      useFormReturn.setValue(`${fieldName}.${index}.text`, originalFields?.[index]?.['text']);
+                      useFormReturn.setValue(`${fieldName}.${index}.disabled`, true);
                       useFormReturn.trigger();
                     }
 

--- a/apps/app/src/routes/wizard/components/wizard-picker.tsx
+++ b/apps/app/src/routes/wizard/components/wizard-picker.tsx
@@ -13,6 +13,7 @@ interface WizardPickerProps {
   triggerValidation?: () => void;
   title: string;
   buttonText: string;
+  addAsSignificantAndReadonly?: boolean;
 }
 
 const WizardPicker: React.FC<WizardPickerProps> = ({
@@ -23,6 +24,7 @@ const WizardPicker: React.FC<WizardPickerProps> = ({
   triggerValidation,
   title,
   buttonText,
+  addAsSignificantAndReadonly,
 }) => {
   // Fetching data from the API
   // console.log('data: ', data);
@@ -89,10 +91,18 @@ const WizardPicker: React.FC<WizardPickerProps> = ({
             existingFields.delete(selectedOption.text);
             return existingField;
           } else {
-            return {
-              tc_is_readonly: true,
-              text: selectedOption.text,
-            };
+            if (addAsSignificantAndReadonly)
+              return {
+                tc_is_readonly: true,
+                nonEditable: true,
+                is_significant: true,
+                text,
+              };
+            else
+              return {
+                is_significant: true,
+                text,
+              };
           }
         }
         return null;

--- a/apps/app/src/routes/wizard/components/wizard-professional-registration-picker.tsx
+++ b/apps/app/src/routes/wizard/components/wizard-professional-registration-picker.tsx
@@ -11,7 +11,6 @@ interface WizardProfessionalRegistrationPickerProps {
   removeAction: UseFieldArrayRemove;
   data: any;
   triggerValidation: () => void;
-  markAllSignificantProReg?: boolean;
 }
 
 const WizardProfessionalRegistrationPicker: React.FC<WizardProfessionalRegistrationPickerProps> = ({
@@ -20,7 +19,6 @@ const WizardProfessionalRegistrationPicker: React.FC<WizardProfessionalRegistrat
   removeAction,
   data,
   triggerValidation,
-  markAllSignificantProReg = false,
 }) => {
   // Fetching data from the API
   // console.log('data: ', data);
@@ -83,7 +81,7 @@ const WizardProfessionalRegistrationPicker: React.FC<WizardProfessionalRegistrat
           return {
             tc_is_readonly: true,
             nonEditable: true,
-            is_significant: markAllSignificantProReg,
+            is_significant: true,
             text,
           };
         }

--- a/apps/app/src/routes/wizard/hooks/wizardUseFieldArray.tsx
+++ b/apps/app/src/routes/wizard/hooks/wizardUseFieldArray.tsx
@@ -86,12 +86,18 @@ const useFormFields = ({
     setEditedFields && setEditedFields((prev) => ({ ...prev, [index]: false }));
     const currentValues: TrackedFieldArrayItem[] = useFormReturn.getValues(fieldName) as TrackedFieldArrayItem[];
     currentValues[index].text = originalFields?.[index]?.text;
-    update(index, {
-      text: originalFields?.[index]?.text,
-      disabled: false,
-      is_readonly: originalFields?.[index]?.is_readonly,
-      is_significant: originalFields?.[index]?.is_significant,
-    });
+    // console.log('handle reset: ', index, originalFields?.[index]?.text);
+    // update for some reason doesn't update the value in the text box
+    // update(index, {
+    //   text: originalFields?.[index]?.text,
+    //   disabled: false,
+    //   is_readonly: originalFields?.[index]?.is_readonly,
+    //   is_significant: originalFields?.[index]?.is_significant,
+    // });
+    useFormReturn.setValue(`${fieldName}.${index}.text`, originalFields?.[index]?.text);
+    useFormReturn.setValue(`${fieldName}.${index}.disabled`, false);
+    useFormReturn.setValue(`${fieldName}.${index}.is_readonly`, originalFields?.[index]?.is_readonly);
+    useFormReturn.setValue(`${fieldName}.${index}.is_significant`, originalFields?.[index]?.is_significant);
   };
 
   return {


### PR DESCRIPTION
- pick lists now pull only from latest version of the profiles, instead of previous version as well
- professional registrations and security screenings titles are no longer rendered if there are no items present for a job profile display
- new professional registrations and security screenings are now added as signficant and readonly in total comp
- fixed an issue where reverting changes on HM edit form would not update the value in text box (similarly, erasing all text and bluring would not put the original text back when disabling input)