### PR TITLE
position profile fixes

### DIFF
--- a/apps/app/src/components/app/common/components/positionProfile.tsx
+++ b/apps/app/src/components/app/common/components/positionProfile.tsx
@@ -17,12 +17,12 @@ interface PositionProfileProps {
 
 const PositionProfile: React.FC<PositionProfileProps> = ({
   positionNumber,
-  positionProfile,
+  positionProfile = null,
   prefix,
   mode = 'full',
   loadingStyle = 'spinner',
   unOccupiedText,
-  orgChartData,
+  orgChartData = null,
 }) => {
   const {
     data: positionProfileData,
@@ -32,7 +32,7 @@ const PositionProfile: React.FC<PositionProfileProps> = ({
     {
       positionNumber: positionNumber?.toString() ?? '',
     },
-    { skip: (positionNumber?.toString() ?? '') == '' },
+    { skip: (positionNumber?.toString() ?? '') == '' || orgChartData != null || positionProfile != null },
   );
   // const [getPositionProfile, { data: positionProfileData, isFetching, error: positionProfileError }] =
   //   useLazyGetPositionProfileQuery();
@@ -84,7 +84,7 @@ const PositionProfile: React.FC<PositionProfileProps> = ({
     }
   }, [positionProfileData]);
 
-  const ministryName = organizationData?.organization?.name || '';
+  const ministryName = organizationData?.organization?.name || positionProfile?.ministry || '';
 
   if (positionProfileError || organizationError) {
     return <span>Could not get position information, please reload the page.</span>;

--- a/apps/app/src/routes/classification-tasks/components/service-request-details.component.tsx
+++ b/apps/app/src/routes/classification-tasks/components/service-request-details.component.tsx
@@ -19,8 +19,6 @@ export const ServiceRequestDetails: React.FC<ServiceRequestDetailsProps> = ({ po
     { skip: !positionRequestData?.positionRequest?.additional_info?.work_location_id },
   );
 
-  // console.log('locationInfo: ', locationInfo);
-
   const submissionDetailsItems = [
     {
       key: 'submittedBy',
@@ -132,7 +130,7 @@ export const ServiceRequestDetails: React.FC<ServiceRequestDetailsProps> = ({ po
       children: (
         <PositionProfile
           positionNumber={positionRequestData?.positionRequest?.additional_info?.excluded_mgr_position_number}
-          positionProfile={positionRequestData?.positionRequest?.reports_to_position}
+          positionProfile={positionRequestData?.positionRequest?.excluded_manager_position}
           orgChartData={positionRequestData?.positionRequest?.orgchart_json}
         ></PositionProfile>
         // <div>

--- a/apps/app/src/routes/total-comp-approved-requests/total-comp-approved-request.page.tsx
+++ b/apps/app/src/routes/total-comp-approved-requests/total-comp-approved-request.page.tsx
@@ -426,16 +426,16 @@ export const TotalCompApprovedRequestPage = () => {
                         </Descriptions.Item>
                         <Descriptions.Item label="Reporting Manager" span={3}>
                           <PositionProfile
-                            positionNumber={data?.positionRequest?.additional_info?.excluded_mgr_position_number}
-                            positionProfile={data?.positionRequest?.excluded_manager_position}
+                            positionNumber={data?.positionRequest?.reports_to_position_id}
+                            positionProfile={data?.positionRequest?.reports_to_position}
                             orgChartData={data?.positionRequest?.orgchart_json}
                             mode="compact"
                           ></PositionProfile>
                         </Descriptions.Item>
                         <Descriptions.Item label="First Band Manager" span={3}>
                           <PositionProfile
-                            positionNumber={data?.positionRequest?.reports_to_position_id}
-                            positionProfile={data?.positionRequest?.reports_to_position}
+                            positionNumber={data?.positionRequest?.additional_info?.excluded_mgr_position_number}
+                            positionProfile={data?.positionRequest?.excluded_manager_position}
                             orgChartData={data?.positionRequest?.orgchart_json}
                             mode="compact"
                           ></PositionProfile>


### PR DESCRIPTION
- was showing reporting manager instead of excluded manager on CS service request page
- was fetching data without need when can pull it from the org chart object or from passed in positionProfile
- reporting manager and first band manager were swapped on total comp approved request status tab
- ministry name was not being displayed for managers on total comp approved request status tab