### PR TITLE
version display fixes

### DIFF
--- a/apps/api/src/modules/job-profile/job-profile.resolver.ts
+++ b/apps/api/src/modules/job-profile/job-profile.resolver.ts
@@ -83,7 +83,7 @@ class Version {
   @Field(() => Number)
   id: number;
 
-  @Field(() => String)
+  @Field(() => Number)
   version: number;
 }
 

--- a/apps/app/src/components/app/header.component.tsx
+++ b/apps/app/src/components/app/header.component.tsx
@@ -51,6 +51,7 @@ export const AppHeader = () => {
     </Menu>
   );
 
+  console.log('import.meta.env: ', import.meta.env);
   return (
     <>
       {import.meta.env.VITE_ENV != 'production' && (

--- a/apps/app/src/components/app/header.module.css
+++ b/apps/app/src/components/app/header.module.css
@@ -191,7 +191,7 @@
     overflow: hidden;
     position: sticky;
     top: 0;
-    z-index: 99999;
+    z-index: 100;
   }
   
   .stripedAlert :global(.ant-alert-content) {

--- a/apps/app/src/components/app/version-select.component.tsx
+++ b/apps/app/src/components/app/version-select.component.tsx
@@ -100,7 +100,11 @@ export const VersionSelect = ({ id, version, selectVersionCallback }: VersionSel
         }
         options={jobProfileVersions}
         onChange={onChange}
-        value={id + '-' + (version ?? (versions ? [...versions].sort((v) => v.version)[0].version : undefined))}
+        value={
+          id +
+          '-' +
+          (version ?? (versions ? [...versions].sort((a, b) => b.version - a.version)[0].version : undefined))
+        }
       >
         <Button>
           Select Version

--- a/apps/app/src/routes/classification-tasks/components/service-request-details.component.tsx
+++ b/apps/app/src/routes/classification-tasks/components/service-request-details.component.tsx
@@ -106,7 +106,7 @@ export const ServiceRequestDetails: React.FC<ServiceRequestDetailsProps> = ({ po
             to={`/job-profiles/${positionRequestData?.positionRequest?.parent_job_profile?.number}?id=${positionRequestData?.positionRequest?.parent_job_profile_id}&version=${positionRequestData?.positionRequest?.parent_job_profile_version}`}
           >
             <Typography.Text type="secondary">
-              Version {positionRequestData?.positionRequest?.parent_job_profile_version} {!currentVersion && '(Latest)'}
+              Version {positionRequestData?.positionRequest?.parent_job_profile_version} {currentVersion && '(Latest) '}
             </Typography.Text>
             <ExportOutlined />
           </Link>

--- a/apps/app/src/routes/job-profiles/components/job-profile-card.component.tsx
+++ b/apps/app/src/routes/job-profiles/components/job-profile-card.component.tsx
@@ -15,7 +15,6 @@ const { Title, Text, Paragraph } = Typography;
 
 export interface JobProfileCardProps {
   data: JobProfileModel;
-  link: string;
 }
 
 export const JobProfileCard = ({ data }: JobProfileCardProps) => {

--- a/apps/app/src/routes/job-profiles/components/job-profile-search-results.component.tsx
+++ b/apps/app/src/routes/job-profiles/components/job-profile-search-results.component.tsx
@@ -36,19 +36,7 @@ export const JobProfileSearchResults = ({
   const [searchParams] = useSearchParams();
   const location = useLocation();
 
-  const isPositionRequestRoute = location.pathname.includes('/requests/positions/');
   const { positionRequestId } = useParams<{ positionRequestId?: string }>();
-
-  const getBasePath = (path: string) => {
-    if (isPositionRequestRoute) return location.pathname.split('/').slice(0, 4).join('/');
-
-    const pathParts = path.split('/');
-    // Check if the last part is a number (ID), if so, remove it
-    if (!isNaN(Number(pathParts[pathParts.length - 1]))) {
-      pathParts.pop(); // Remove the last part (job profile ID)
-    }
-    return pathParts.join('/');
-  };
 
   const getLinkPath = (profileNumber: number) => {
     // `${getBasePath(location.pathname)}/${d.id}${
@@ -61,10 +49,13 @@ export const JobProfileSearchResults = ({
     }
 
     // Check if we're on the /requests/positions route
-    searchParams.delete('id');
-    searchParams.delete('version');
-    searchParams.delete('selectedProfile');
     const newSearchParams = new URLSearchParams(searchParams.toString());
+
+    // do not change searchParams directly as other parts of code may use it
+    newSearchParams.delete('id');
+    newSearchParams.delete('version');
+    newSearchParams.delete('selectedProfile');
+
     if (positionRequestId) {
       newSearchParams.set('selectedProfile', profileNumber.toString());
       return `/requests/positions/${positionRequestId}?${newSearchParams.toString()}`;
@@ -119,12 +110,7 @@ export const JobProfileSearchResults = ({
           {(data?.jobProfiles ?? []).map((d) => (
             <li key={d.id} onClick={() => onSelectProfile && onSelectProfile(d)}>
               <Link to={getLinkPath(d.number)} replace tabIndex={-1}>
-                <JobProfileCard
-                  data={d}
-                  link={`${getBasePath(location.pathname)}/${d.number}${
-                    searchParams.toString().length > 0 ? `?${searchParams.toString()}` : ''
-                  }`}
-                />
+                <JobProfileCard data={d} />
               </Link>
             </li>
           ))}

--- a/apps/app/src/routes/job-profiles/components/job-profile-search.component.tsx
+++ b/apps/app/src/routes/job-profiles/components/job-profile-search.component.tsx
@@ -328,8 +328,7 @@ export const JobProfileSearch: React.FC<JobProfileSearchProps> = ({
     // construct new url params
     // Update URL parameters if needed
     if (selectedProfileFromUrl) newSearchParams.set('selectedProfile', selectedProfileFromUrl);
-    if (idFromUrl) newSearchParams.set('id', idFromUrl);
-    if (versionFromUrl) newSearchParams.set('version', versionFromUrl);
+
     if (pageFromURL != 1) newSearchParams.set('page', pageFromURL.toString());
     if (searchFromURL) newSearchParams.set('search', searchFromURL.toString());
     if (pageSizeFromURL) newSearchParams.set('pageSize', pageSizeFromURL.toString());
@@ -342,6 +341,8 @@ export const JobProfileSearch: React.FC<JobProfileSearchProps> = ({
     if (classificationValues) newSearchParams.set('classification_id__in', classificationValues);
     // if (careerGroupValues) newSearchParams.set('career_group_id__in', careerGroupValues);
     if (ministryValues) newSearchParams.set('ministry_id__in', ministryValues);
+    if (idFromUrl) newSearchParams.set('id', idFromUrl);
+    if (versionFromUrl) newSearchParams.set('version', versionFromUrl);
 
     const jobFamilyChanged = newSearchParams.get('job_family_id__in') != searchParams.get('job_family_id__in');
     const jobStreamChanged = newSearchParams.get('job_stream_id__in') != searchParams.get('job_stream_id__in');
@@ -365,6 +366,7 @@ export const JobProfileSearch: React.FC<JobProfileSearchProps> = ({
         { replace: true },
       );
     } else {
+      // filters did not change, but some other parameters did
       // Only update search params if there's a change
       if (searchParams.toString() !== newSearchParams.toString()) {
         // console.log('navigating.. A', getBasePath(location.pathname));

--- a/apps/app/src/routes/job-profiles/components/job-profile.component.tsx
+++ b/apps/app/src/routes/job-profiles/components/job-profile.component.tsx
@@ -439,11 +439,11 @@ export const JobProfile: React.FC<JobProfileProps> = ({
   useEffect(() => {
     // If profileData exists, use it to set the form state
     if (versionedProfileData) {
+      // once data by id and version loads, set that data
       setEffectiveData(versionedProfileData.jobProfile);
       setEffectiveDataExtra(versionedProfileData.jobProfile);
     } else if (id && version && !isLoadingVersioned) {
-      // If no profileData is provided and an id exists, fetch the data
-      // OR profileData was provided, but we also want to run a diff
+      // fetch by id and version when present in search query
       triggerGetJobProfileById({ id: parseInt(id ?? '-1'), version: parseInt(version ?? '-1') });
     }
   }, [searchParams, versionedProfileData, triggerGetJobProfileById, isLoadingVersioned, id, version]);
@@ -456,8 +456,7 @@ export const JobProfile: React.FC<JobProfileProps> = ({
     } else if (!profileData && jobNumber && !(id && version)) {
       triggerGetJobProfileByNumber({ number: +jobNumber });
     } else if (profileData && showDiff && parentJobProfileId) {
-      // If no profileData is provided and an id exists, fetch the data
-      // OR profileData was provided, but we also want to run a diff
+      // we're in diff mode - load parent profile to compare to
       triggerGetJobProfile({ id: parentJobProfileId, version: parentJobProfileVersion });
     }
   }, [

--- a/apps/app/src/routes/total-comp-approved-requests/total-comp-approved-request.page.tsx
+++ b/apps/app/src/routes/total-comp-approved-requests/total-comp-approved-request.page.tsx
@@ -118,7 +118,7 @@ export const TotalCompApprovedRequestPage = () => {
             to={`/job-profiles/${data?.positionRequest?.parent_job_profile?.number}?id=${data?.positionRequest?.parent_job_profile_id}&version=${data?.positionRequest?.parent_job_profile_version}`}
           >
             <Typography.Text type="secondary">
-              Version {data?.positionRequest?.parent_job_profile_version} {!currentVersion && '(Latest)'}
+              Version {data?.positionRequest?.parent_job_profile_version} {currentVersion && '(Latest) '}
             </Typography.Text>
             <ExportOutlined />
           </Link>


### PR DESCRIPTION
- changed getLinkPath function to not modify searchParams directly as other parts of code may use it
- removed unusued code in profile-search-results/ job-profile-card
- on total-comp-approved-request and serve-request details pages was showing (latest) when it wasn't latest
- "versions" was returning wrong type (string instead of number)
- version select component wasn't selecting correct latest version by default in the dropdown because sort wasn't ordering items correctly
- made id and version append last in searchparams to fix an issue where selecting a version with filters enabled would reset the selected profile