### PR TITLE
stage patches

### DIFF
--- a/apps/api/src/modules/external/position.service.ts
+++ b/apps/api/src/modules/external/position.service.ts
@@ -68,6 +68,9 @@ export class PositionService {
     return position;
   }
 
+  /* This end point is used to get the position profile for a given position number. 
+     It returns the position details along with the employee details if the position has an employee. 
+  */
   async getPositionProfile(positionNumber: string, extraInfo = false): Promise<PositionProfile[]> {
     if (!positionNumber) throw AlexandriaError('Position number is required');
     const positionDetails = await this.getPosition({ where: { id: positionNumber } });

--- a/apps/api/src/modules/position-request/position-request.service.ts
+++ b/apps/api/src/modules/position-request/position-request.service.ts
@@ -299,21 +299,29 @@ export class PositionRequestApiService {
       throw AlexandriaError('Failed to update org chart');
     }
 
-    const reportsTo = (await this.positionService.getPositionProfile(positionRequest.reports_to_position_id, true))[0];
-    const excludedMgr = (
-      await this.positionService.getPositionProfile(
-        (positionRequest.additional_info as Record<string, any>).excluded_mgr_position_number,
-        true,
-      )
-    )[0];
+    try {
+      const reportsTo = (
+        await this.positionService.getPositionProfile(positionRequest.reports_to_position_id, true)
+      )[0];
+      const excludedMgr = (
+        await this.positionService.getPositionProfile(
+          (positionRequest.additional_info as Record<string, any>).excluded_mgr_position_number,
+          true,
+        )
+      )[0];
 
-    await this.prisma.positionRequest.update({
-      where: { id },
-      data: {
-        reports_to_position: reportsTo,
-        excluded_manager_position: excludedMgr,
-      },
-    });
+      await this.prisma.positionRequest.update({
+        where: { id },
+        data: {
+          reports_to_position: reportsTo,
+          excluded_manager_position: excludedMgr,
+        },
+      });
+    } catch (error) {
+      this.logger.error(error);
+      throw AlexandriaError('Failed to update manager information.');
+    }
+
     // CRM Incident Managements
     let crm_id;
     let crm_lookup_name;

--- a/apps/app/src/components/shared/download-job-profile/download-job-profile.component.tsx
+++ b/apps/app/src/components/shared/download-job-profile/download-job-profile.component.tsx
@@ -70,7 +70,7 @@ export const DownloadJobProfileComponent = ({
         console.log('generaring with profile: ', profile);
       }
 
-      // console.log('prData?.positionRequest: ', prData?.positionRequest);
+      // console.log('positionRequest: ', positionRequest);
       const document =
         profile != null
           ? generateJobProfile({
@@ -267,7 +267,7 @@ export const DownloadJobProfileComponent = ({
   }
 
   return children != null ? (
-    <div
+    <span
       style={{ position: 'relative' }}
       onClick={async () => {
         console.log('do download');
@@ -293,7 +293,7 @@ export const DownloadJobProfileComponent = ({
           <LoadingComponent mode={'small'} />
         </span>
       )}
-    </div>
+    </span>
   ) : (
     <Button
       style={style}

--- a/apps/app/src/redux/services/graphql-api/position-request.api.ts
+++ b/apps/app/src/redux/services/graphql-api/position-request.api.ts
@@ -469,6 +469,8 @@ export const positionRequestApi = graphqlApi.injectEndpoints({
                 step
                 max_step_completed
                 reports_to_position_id
+                reports_to_position
+                excluded_manager_position
                 parent_job_profile_id
                 parent_job_profile_version
                 profile_json

--- a/apps/app/src/routes/my-position-requests/my-position-requests.page.tsx
+++ b/apps/app/src/routes/my-position-requests/my-position-requests.page.tsx
@@ -3,7 +3,7 @@
 import { CloseOutlined } from '@ant-design/icons';
 import { Button, Card, Col, Row, Select, Tag } from 'antd';
 import Search from 'antd/es/input/Search';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import '../../components/app/common/css/filtered-table.page.css';
 import '../../components/app/common/css/select-external-tags.css';
@@ -14,10 +14,12 @@ import { useGetPositionRequestUserClassificationsQuery } from '../../redux/servi
 import MyPositionsTable from './components/my-position-requests-table.component';
 
 export const MyPositionsPage = () => {
-  const statusFilterDataMap = Object.entries(statusIconColorMap).map(([value, data]) => ({
-    label: data.text,
-    value,
-  }));
+  const statusFilterDataMap = useMemo(() => {
+    return Object.entries(statusIconColorMap).map(([value, data]) => ({
+      label: data.text,
+      value,
+    }));
+  }, []);
 
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);

--- a/apps/app/src/routes/total-comp-approved-requests/components/position-requests-search.component.tsx
+++ b/apps/app/src/routes/total-comp-approved-requests/components/position-requests-search.component.tsx
@@ -2,7 +2,7 @@
 import { CloseOutlined } from '@ant-design/icons';
 import { Button, Card, Col, DatePicker, Input, Row, Tag } from 'antd';
 import dayjs from 'dayjs';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import Select, { components } from 'react-select';
 import { statusIconColorMap } from '../../../components/app/utils/statusIconColorMap.utils';
@@ -64,10 +64,12 @@ export const PositionRequestsSearch: React.FC<JobProfileSearchProps> = ({
   allSelections,
   setAllSelections,
 }) => {
-  const statusFilterDataMap = Object.entries(statusIconColorMap).map(([value, data]) => ({
-    label: data.text,
-    value,
-  }));
+  const statusFilterDataMap = useMemo(() => {
+    return Object.entries(statusIconColorMap).map(([value, data]) => ({
+      label: data.text,
+      value,
+    }));
+  }, []);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();


### PR DESCRIPTION
- wrapped reports to and excluded manager updating during position creation into a try-catch block for better error handling
- reverted download button to be a span, otherwise does not render properly in a context menu when invoked from a table
- added reports_to_position and excluded_manager_position to return when user creates position. Without this the downloaded document will not contain this information if downloaded immediately after
- fixed infinite render loop due to lack of memo on statusFilterDataMap